### PR TITLE
Fix shallow copy in ER1a

### DIFF
--- a/sbfl/sbfl_formula.py
+++ b/sbfl/sbfl_formula.py
@@ -42,7 +42,7 @@ def M2(e_p, n_p, e_f, n_f):
     return e_f/(e_f + n_p + 2 * n_f + 2 * e_p)
 
 def ER1a(e_p, n_p, e_f, n_f):
-    scores = n_p
+    scores = np.copy(n_p)
     scores[n_f > 0] = -1
     return scores
 

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -322,7 +322,7 @@ def test_euclid():
 """
 Test shallow copy
 """
-def test_er1a_shallow_copy():
+def test_er1a_deep_copy():
     e_p = np.array([2, 1, 0, 0])
     n_p = np.array([0, 2, 1, 0])
     e_f = np.array([0, 0, 2, 1])
@@ -330,4 +330,4 @@ def test_er1a_shallow_copy():
     scores = formula.ER1a(e_p, n_p, e_f, n_f)
 
     assert_array_equal(scores, np.array([-1, 2, 1, -1]))
-    assert_array_equal(n_p, np.array([-1, 2, 1, -1]), 'Shallow copy not performed')
+    assert_array_equal(n_p, np.array([0, 2, 1, 0]), 'Shallow copy occurred')


### PR DESCRIPTION
Fix a bug: a side effect -- shallow copy was occurred in ER1a.
Calling ER1a method may change `n_p`

Please refer #9