### PR TITLE
Fix shallow copy in Wong3

### DIFF
--- a/sbfl/sbfl_formula.py
+++ b/sbfl/sbfl_formula.py
@@ -65,9 +65,9 @@ def Wong3(e_p, n_p, e_f, n_f):
     cond1 = (e_p > 2) & (e_p <= 10)
     cond2 = e_p > 10
 
-    h = e_p
-    h[cond1] = 2 + 0.1 * (e_p[cond1] - 2)
-    h[cond2] = 2.8 + 0.001 * (e_p[cond2] - 10)
+    h = e_p.copy()
+    h[cond1] = 2 + 0.1 * (h[cond1] - 2)
+    h[cond2] = 2.8 + 0.001 * (h[cond2] - 10)
 
     return e_f - h
 

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -331,3 +331,14 @@ def test_er1a_deep_copy():
 
     assert_array_equal(scores, np.array([-1, 2, 1, -1]))
     assert_array_equal(n_p, np.array([0, 2, 1, 0]), 'Shallow copy occurred')
+
+
+def test_wong3_deep_copy():
+    e_p = np.array([3, 11, 1, 0])
+    n_p = np.array([0, 3, 11, 1])
+    e_f = np.array([1, 0, 3, 11])
+    n_f = np.array([11, 1, 0, 3])
+    scores = formula.Wong3(e_p, n_p, e_f, n_f)
+
+    assert_array_equal(scores, np.array([-1, -2,  2, 11]))
+    assert_array_equal(e_p, np.array([2, 2, 1, 0]), 'Shallow copy not occurred')

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -341,4 +341,4 @@ def test_wong3_deep_copy():
     scores = formula.Wong3(e_p, n_p, e_f, n_f)
 
     assert_array_equal(scores, np.array([-1, -2,  2, 11]))
-    assert_array_equal(e_p, np.array([2, 2, 1, 0]), 'Shallow copy not occurred')
+    assert_array_equal(e_p, np.array([3, 11, 1, 0]), 'Shallow copy occurred')


### PR DESCRIPTION
Fix a bug: a side effect -- shallow copy was occurred in **Wong3**.
Calling **Wong3** method may change `e_p`

This PR relates c009945aa9770b6891fd11befdf324ff4ac0beec and #10 